### PR TITLE
chore(core): Remove unnecessary slice.

### DIFF
--- a/index.test.ts
+++ b/index.test.ts
@@ -283,3 +283,20 @@ it('throws if the last item throws', async () => {
   }
   expect(rejected).toBe(true);
 });
+
+it('does not mutate the collection', async () => {
+  const a = {};
+  const b = {};
+  const c = {};
+  const collection = [a, b, c];
+  await pool({
+    collection,
+    task: () => new Promise(resolve => setTimeout(resolve, 100)),
+    maxConcurrency: 10
+  });
+
+  expect(collection.length).toBe(3);
+  expect(collection[0]).toBe(a);
+  expect(collection[1]).toBe(b);
+  expect(collection[2]).toBe(c);
+});

--- a/index.ts
+++ b/index.ts
@@ -31,9 +31,7 @@ async function pool<T, R>({
   }
 
   const results: Array<[R, number]> = [];
-  const mutableCollection = collection
-    .slice()
-    .map((t, i) => [t, i] as [T, number]);
+  const mutableCollection = collection.map((t, i) => [t, i] as [T, number]);
 
   let available = maxConcurrency;
   let done = false;


### PR DESCRIPTION
Since it's already calling `map`, there doesn't seem to be any purpose to call `slice` to make a shallow clone.